### PR TITLE
allow setting remote file metadata

### DIFF
--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -11,6 +11,11 @@ const Relation = mongoose.model('relations', relationSchema);
 
 export default async function(app: Express) {
 
+  function fixId(doc: any) {
+    doc.id = doc._id;
+    delete doc._id;
+  }
+
   app.get('/api/v1/resources', async (_, res) => {
     Resource.find().distinct('_id', function (err: Error, resources: string[]) {
       if(err) {res.status(500).send(JSON.stringify({status: 500, ...err}));}
@@ -19,33 +24,49 @@ export default async function(app: Express) {
       }
     });
   });
-  
+
 
   // TODO: build this
   app.get('/api/v1/resources/search', async (_, res) => {
       res.status(501);
       res.end(JSON.stringify('{"status":501}'));
   });
-  
+
   // TODO: build this
   app.get('/api/v1/resources/scan', async (_, res) => {
       res.status(501);
       res.end(JSON.stringify('{"status":501}'));
   });
-  
+
   /* Resource Life Cycle Routes */
 
-   /**
-   * Dummy route because GUI wants a content upload URL, even when we're just copying a YouTube link
-   * TO DO: remove the upload content requirement from the GUI, so that YouTube (or other web) links no longer have to post to an dummy file upload link
+  /*
+   * Endpoint for setting remote file metadata
    */
-    app.post('/api/v1/resources/:id/content/:token', authorizeRequest, async (req, res) => {
-      return res.status(200).send({
-        status: 200,
-        resource: {
-          id: req.params.id
-        }
-      })
+  app.post('/api/v1/resources/:id/content/:token', authorizeRequest, async (req, res) => {
+    let files = req.body?.remoteFiles || [];
+    files = files?.map((file: any) => {
+      if (!file?.mime && file?.mimeType) {
+        // copy mimetype
+        // The ayamel player requires mime to be set but
+        // the backend does not set a mime field.
+        file.mime = file.mimeType;
+      }
+      return file;
+    });
+
+    Resource.findByIdAndUpdate(req.params.id, { $set: { "content.files": files } }, { new: true }, (err, resource) => {
+      if (err) {
+        res.status(500).send(JSON.stringify({status: 500, error: err}));
+      }
+      else {
+        fixId(resource);
+        res.status(200).send({
+          status: 200,
+          resource: resource,
+        })
+      }
+    });
   });
 
   /**
@@ -60,8 +81,8 @@ export default async function(app: Express) {
         res.send(JSON.stringify({status: 200, resource: {id: resource._id}, contentUploadUrl: `/api/v1/resources/${resource._id}/content/dummytoken-${resource._id}`}));
       }
     });
-});
-  
+  });
+
   app.put('/api/v1/resources/:id', authorizeRequest, async (req, res) => {
       const id = req.params.id;
       Resource.findByIdAndUpdate(id, req.body, {runValidators: true}, function (err) {
@@ -73,12 +94,12 @@ export default async function(app: Express) {
         }
       });
   });
-  
+
   app.get('/api/v1/resources/:id', async (req, res) => {
       const id = req.params.id;
       const docp = Resource.findById(id);
       // Get all the relations for which this resource
-      // is an argument (subject or object). 
+      // is an argument (subject or object).
       const relp = Relation
         .find({ $or: [ { subjectId: id }, { objectId: id } ] });
       let doc, rels;
@@ -90,15 +111,13 @@ export default async function(app: Express) {
         return;
       }
 
-      if (doc) {    
+      if (doc) {
         // internal database _id needs to be
         // translated to external unprefixed id
         for (const rel of rels) {
-          rel.id = rel._id;
-          delete rel._id;
+          fixId(rel);
         }
-        doc.id = doc._id;
-        delete doc._id;
+        fixId(doc);
 
         // merge relations into returned resource document
         doc.relations = rels;
@@ -109,7 +128,7 @@ export default async function(app: Express) {
         res.send(JSON.stringify({status:404}));
       }
   });
-  
+
   app.delete('/api/v1/resources/:id', authorizeRequest, async (req, res) => {
       Resource.findByIdAndDelete(req.params.id, null, function (err) {
         if(err) {


### PR DESCRIPTION
This should fix viewing resources in the ayamel player.

Needed to save the changes into `resource.content.files` and make sure there was a `mime` field which is the same as the mimeType field AFAICT.